### PR TITLE
Add README.md to docker images

### DIFF
--- a/docker/ros-humble/README.md
+++ b/docker/ros-humble/README.md
@@ -1,0 +1,20 @@
+# ROS Humble Dev Container
+
+This Docker image provides a development environment based on ROS Humble Hawksbill. It is designed for developing ROS 2 applications and includes Claude Code for AI-assisted development.
+
+## Base Image
+- `ros:humble`
+
+## Key Features
+- **ROS 2 Humble**: Pre-installed ROS 2 Humble base.
+- **Build Tools**: Includes `colcon` build tools (`python3-colcon-core`, `python3-colcon-common-extensions`).
+- **Claude Code**: Pre-installed `@anthropic-ai/claude-code` for AI coding assistance.
+- **Developer Tools**:
+  - `gh` (GitHub CLI)
+  - `git`
+  - `zsh`
+  - `curl`
+  - Node.js (LTS)
+- **User Configuration**:
+  - Non-root `ubuntu` user (UID 1001)
+  - Passwordless `sudo` access

--- a/docker/ros-noetic/README.md
+++ b/docker/ros-noetic/README.md
@@ -1,0 +1,20 @@
+# ROS Noetic Dev Container
+
+This Docker image provides a development environment based on ROS Noetic Ninjemys. It is designed for developing ROS 1 applications and includes Claude Code for AI-assisted development.
+
+## Base Image
+- `ros:noetic`
+
+## Key Features
+- **ROS Noetic**: Pre-installed ROS Noetic base.
+- **Build Tools**: Includes `catkin-tools` (`python3-catkin-tools`).
+- **Claude Code**: Pre-installed `@anthropic-ai/claude-code` for AI coding assistance.
+- **Developer Tools**:
+  - `gh` (GitHub CLI)
+  - `git`
+  - `zsh`
+  - `curl`
+  - Node.js (LTS)
+- **User Configuration**:
+  - Non-root `ubuntu` user (UID 1001)
+  - Passwordless `sudo` access

--- a/docker/ubuntu-focal/README.md
+++ b/docker/ubuntu-focal/README.md
@@ -1,0 +1,20 @@
+# Ubuntu Focal Dev Container
+
+This Docker image provides a general-purpose development environment based on Ubuntu 20.04 (Focal Fossa). It includes essential development tools and Claude Code for AI-assisted development.
+
+## Base Image
+- `ubuntu:focal`
+
+## Key Features
+- **Ubuntu 20.04**: Stable LTS base.
+- **Claude Code**: Pre-installed `@anthropic-ai/claude-code` for AI coding assistance.
+- **Developer Tools**:
+  - `gh` (GitHub CLI)
+  - `git`
+  - `zsh`
+  - `sudo`
+  - `curl`
+  - Node.js (LTS)
+- **User Configuration**:
+  - Non-root `ubuntu` user (UID 1001)
+  - Passwordless `sudo` access

--- a/docker/ubuntu-noble/README.md
+++ b/docker/ubuntu-noble/README.md
@@ -1,0 +1,20 @@
+# Ubuntu Noble Dev Container
+
+This Docker image provides a general-purpose development environment based on Ubuntu 24.04 (Noble Numbat). It includes essential development tools and Claude Code for AI-assisted development.
+
+## Base Image
+- `ubuntu:noble`
+
+## Key Features
+- **Ubuntu 24.04**: Latest LTS base.
+- **Claude Code**: Pre-installed `@anthropic-ai/claude-code` for AI coding assistance.
+- **Developer Tools**:
+  - `gh` (GitHub CLI)
+  - `git`
+  - `zsh`
+  - `sudo`
+  - `curl`
+  - Node.js (LTS)
+- **User Configuration**:
+  - Non-root `ubuntu` user
+  - Passwordless `sudo` access


### PR DESCRIPTION
This PR adds README.md files to ros-humble, ros-noetic, ubuntu-focal, and ubuntu-noble docker directories. These files describe the base image, key features, and user configuration for each image.